### PR TITLE
Refactor file components, add in pre-commit config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ colorama = "^0.4.3"
 python-box = "^4.0"
 virtualenv = "^20.0"
 redbaron = "^0.9.2"
-requests = "^2.23.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ colorama = "^0.4.3"
 python-box = "^4.0"
 virtualenv = "^20.0"
 redbaron = "^0.9.2"
+requests = "^2.23.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/zygoat/__init__.py
+++ b/zygoat/__init__.py
@@ -3,6 +3,6 @@ from . import utils  # noqa
 
 # Disable long tracebacks
 import sys
-sys.tracebacklimit = 0
+sys.tracebacklimit = 2
 
 __version__ = '0.1.0'

--- a/zygoat/components/__init__.py
+++ b/zygoat/components/__init__.py
@@ -1,13 +1,16 @@
 from .base import Component  # noqa
+from .file_component import FileComponent # noqa
 from .settings_component import SettingsComponent  # noqa
 
 from .editorconfig import editorconfig
+from .precommit import precommitconfig
 from .docker_compose import docker_compose
 from .backend import backend
 from .frontend import frontend
 
 components = [
     editorconfig,
+    precommitconfig,
     docker_compose,
     backend,
     frontend,

--- a/zygoat/components/editorconfig.py
+++ b/zygoat/components/editorconfig.py
@@ -1,33 +1,9 @@
-from importlib import resources as il_resources
-
-import logging
-import os
-
-from zygoat.components import Component
-from zygoat.constants import Phases
-from . import resources
-
-log = logging.getLogger()
-file_name = '.editorconfig'
+from zygoat.components import FileComponent, resources
 
 
-class EditorConfig(Component):
-    def create(self):
-        log.info(f'Creating {file_name}')
-
-        with open(file_name, 'w') as f:
-            f.write(il_resources.read_text(resources, file_name))
-
-    def update(self):
-        self.call_phase(Phases.CREATE, force_create=True)
-
-    def delete(self):
-        log.warning(f'Deleting {file_name}')
-        os.remove(file_name)
-
-    @property
-    def installed(self):
-        return os.path.exists(file_name)
+class EditorConfig(FileComponent):
+    filename = '.editorconfig'
+    resource_pkg = resources
 
 
 editorconfig = EditorConfig()

--- a/zygoat/components/editorconfig.py
+++ b/zygoat/components/editorconfig.py
@@ -1,9 +1,8 @@
-from zygoat.components import FileComponent, resources
+from zygoat.components import FileComponent
 
 
 class EditorConfig(FileComponent):
     filename = '.editorconfig'
-    resource_pkg = resources
 
 
 editorconfig = EditorConfig()

--- a/zygoat/components/file_component.py
+++ b/zygoat/components/file_component.py
@@ -1,0 +1,50 @@
+from importlib import resources as il_resources
+
+import logging
+import os
+
+from zygoat.components import Component
+from zygoat.constants import Phases
+
+
+log = logging.getLogger()
+
+
+class FileComponent(Component):
+    """
+    Use this when you want to create a file component that
+    tracks the contents of the file that 'filename' points to.
+    Note that this file must exist in zygoat's path here:
+    'zygoat/components/resources/'.
+    """
+    def check_setup(f):
+        def wrapper(self, *args, **kwargs):
+            if not self.filename:
+                raise NotImplementedError(
+                        'You must specify cls.filename!')
+            if not self.resource_pkg:
+                raise NotImplementedError(
+                        'You must specify cls.resources_pkg!')
+            return f(self, *args, **kwargs)
+        return wrapper
+
+    @check_setup
+    def create(self):
+        log.info(f'Creating {self.filename}')
+
+        with open(self.filename, 'w') as f:
+            f.write(il_resources.read_text(self.resource_pkg, self.filename))
+
+    @check_setup
+    def update(self):
+        self.call_phase(Phases.CREATE, force_create=True)
+
+    @check_setup
+    def delete(self):
+        log.warning(f'Deleting {self.filename}')
+        os.remove(self.filename)
+
+    @check_setup
+    @property
+    def installed(self):
+        return os.path.exists(self.filename)

--- a/zygoat/components/precommit.py
+++ b/zygoat/components/precommit.py
@@ -1,9 +1,8 @@
-from zygoat.components import FileComponent, resources
+from zygoat.components import FileComponent
 
 
 class PreCommitConfig(FileComponent):
     filename = '.pre-commit-config.yaml'
-    resource_pkg = resources
 
 
 precommitconfig = PreCommitConfig()

--- a/zygoat/components/precommit.py
+++ b/zygoat/components/precommit.py
@@ -1,0 +1,9 @@
+from zygoat.components import FileComponent, resources
+
+
+class PreCommitConfig(FileComponent):
+    filename = '.pre-commit-config.yaml'
+    resource_pkg = resources
+
+
+precommitconfig = PreCommitConfig()

--- a/zygoat/components/resources/.pre-commit-config.yaml
+++ b/zygoat/components/resources/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: flake8
+      - id: check-json
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.1.0
+    hooks:
+      - id: python-safety-dependencies-check
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
+    hooks:
+      - id: bandit


### PR DESCRIPTION
This adds in a pre-commit config file to all projects and keeps it up-to-date. If we're enforcing this stuff on PRs, we might as well make it available as a pre-commit hook. Note that you still have to install (`pre-commit install`), so that it's opt in.

Removed eslint and prettier stuff because I'll 1) need to add configuration files in for `eslint` too and 2) prettier was changing up some of the general code written in this repo that gets copied over and so I want to make sure that's working correctly before we enforce. But we will at some point need to move the CI stuff we have from other repos onto this one so that we don't get linting errors in the future in other repos that was generated here.

Tested creating and updating, works as expected.

Zygoat is pure *magic* @markrawls it's awesome