### PR TITLE
Add cookie configuration to the Django settings

### DIFF
--- a/zygoat/components/backend/settings/__init__.py
+++ b/zygoat/components/backend/settings/__init__.py
@@ -7,6 +7,7 @@ from .database_config import database_config
 from .debug_config import debug_config
 from .installed_apps import installed_apps
 from .allowed_hosts import allowed_hosts
+from .cookies import cookies
 
 log = logging.getLogger()
 
@@ -31,4 +32,13 @@ class Settings(SettingsComponent):
         return red.find('name', value='environ') is not None
 
 
-settings = Settings(sub_components=[secret_key, database_config, debug_config, installed_apps, allowed_hosts])
+settings_sub_components = [
+    secret_key,
+    database_config,
+    debug_config,
+    installed_apps,
+    allowed_hosts,
+    cookies,
+]
+
+settings = Settings(sub_components=settings_sub_components)

--- a/zygoat/components/backend/settings/cookies.py
+++ b/zygoat/components/backend/settings/cookies.py
@@ -1,0 +1,47 @@
+import logging
+
+from zygoat.components import SettingsComponent
+
+log = logging.getLogger()
+
+
+secure_cookie_string = """\
+if not DEBUG:
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+"""
+
+
+class Cookies(SettingsComponent):
+    def create(self):
+        red = self.parse()
+
+        log.info('Adding cookie configuration')
+
+        red.extend([
+            '\n',
+            '\n',
+            '# Cookies',
+            '\n',
+            "SHARED_DOMAIN = env.str('DJANGO_SHARED_DOMAIN', default=None)",
+            '\n',
+            'CSRF_COOKIE_DOMAIN = SHARED_DOMAIN',
+            '\n',
+            'SESSION_COOKIE_DOMAIN = SHARED_DOMAIN',
+            '\n',
+            "SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'",
+            '\n',
+            'SESSION_COOKIE_AGE = 604800  # One week in seconds',
+            '\n',
+            secure_cookie_string,
+        ])
+
+        self.dump(red)
+
+    @property
+    def installed(self):
+        red = self.parse()
+        return red.find('name', value='SESSION_ENGINE') is not None
+
+
+cookies = Cookies()


### PR DESCRIPTION
If there is a better way to add the if statement and its contents using RedBaron let me know. I couldn't find anything nicer than this.

The way that we are currently handling settings, It seems like we run the risk of overwriting changes made by the app that was created by Zygoat and is being upgraded. An alternative would be to create a separate settings file that is imported into the primary settings file, which would allow apps using Zygoat to override the settings and not have to worry about those changes being clobbered when upgrading Zygoat versions. Thoughts?