### PR TITLE
CONFIG: remove config on delete

### DIFF
--- a/zygoat/cli.py
+++ b/zygoat/cli.py
@@ -53,6 +53,9 @@ def delete():
     for component in reversed(components):
         component.call_phase(Phases.DELETE)
 
+    # remove zygoat settings file
+    Config.delete()
+
 
 @cli.command(help='Calls the update phase on all included build components')
 def update():

--- a/zygoat/config.py
+++ b/zygoat/config.py
@@ -65,3 +65,7 @@ class Config(object):
     def dump(cls, data):
         with cls.settings_file(mode='w') as f:
             yaml.dump(data.to_dict(), f)
+
+    @classmethod
+    def delete(cls):
+        os.remove(find_nearest(config_file_name))


### PR DESCRIPTION
`zygote_settings.yml` was not being cleaned up during `delete`