### PR TITLE
Allow Zygoat Django settings to be extended

### DIFF
--- a/zygoat/components/backend/settings/__init__.py
+++ b/zygoat/components/backend/settings/__init__.py
@@ -20,22 +20,22 @@ manually. Instead, update settings via this package's __init__.py.
 
 class Settings(SettingsComponent):
     def create(self):
-        log.info('Making python package for Django settings')
+        log.info("Making python package for Django settings")
         os.mkdir(self.settings_directory)
 
-        log.info('Moving the django settings into the settings package')
+        log.info("Moving the django settings into the settings package")
         os.rename(self.initial_settings_file_path, self.settings_file_path)
 
-        log.info('Creating import for zygoat settings in __init__.py')
-        with open(os.path.join(self.settings_directory, '__init__.py'), 'a') as f:
-            f.write(f'from .{SettingsComponent.MODULE_NAME} import *  # noqa\n')
+        log.info("Creating import for zygoat settings in __init__.py")
+        with open(os.path.join(self.settings_directory, "__init__.py"), "a") as f:
+            f.write(f"from .{SettingsComponent.MODULE_NAME} import *  # noqa\n")
 
         red = self.parse()
 
-        log.info('Adding comment to Zygoat settings file')
+        log.info("Adding comment to Zygoat settings file")
         red[0].value = zygoat_settings_comment
 
-        first_import_index = red.index(red.find('importnode'))
+        first_import_index = red.index(red.find("importnode"))
 
         log.info("Inserting environ import into django settings")
         red.insert(first_import_index + 1, "import environ")

--- a/zygoat/components/settings_component.py
+++ b/zygoat/components/settings_component.py
@@ -6,16 +6,42 @@ from zygoat.utils.files import repository_root
 from zygoat.constants import Projects
 from . import Component
 
-file_name = "settings.py"
-
 
 class SettingsComponent(Component):
+    ORIGINAL_FILE_NAME = 'settings.py'
+    DIRECTORY_NAME = 'settings'
+    MODULE_NAME = 'zygoat_settings'
+    FILE_NAME = f'{MODULE_NAME}.py'
+
+    @property
+    def initial_settings_file_path(self):
+        return os.path.join(
+            Projects.BACKEND,
+            Projects.BACKEND,
+            SettingsComponent.ORIGINAL_FILE_NAME
+        )
+
+    @property
+    def settings_directory(self):
+        return os.path.join(
+            Projects.BACKEND,
+            Projects.BACKEND,
+            SettingsComponent.DIRECTORY_NAME,
+        )
+
+    @property
+    def settings_file_path(self):
+        return os.path.join(
+            self.settings_directory,
+            SettingsComponent.FILE_NAME,
+        )
+
     def parse(self):
         with repository_root():
-            with open(os.path.join(Projects.BACKEND, Projects.BACKEND, file_name)) as f:
+            with open(self.settings_file_path) as f:
                 return RedBaron(f.read())
 
     def dump(self, data):
         with repository_root():
-            with open(os.path.join(Projects.BACKEND, Projects.BACKEND, file_name), "w") as f:
+            with open(self.settings_file_path, 'w') as f:
                 f.write(data.dumps())

--- a/zygoat/components/settings_component.py
+++ b/zygoat/components/settings_component.py
@@ -8,33 +8,26 @@ from . import Component
 
 
 class SettingsComponent(Component):
-    ORIGINAL_FILE_NAME = 'settings.py'
-    DIRECTORY_NAME = 'settings'
-    MODULE_NAME = 'zygoat_settings'
-    FILE_NAME = f'{MODULE_NAME}.py'
+    ORIGINAL_FILE_NAME = "settings.py"
+    DIRECTORY_NAME = "settings"
+    MODULE_NAME = "zygoat_settings"
+    FILE_NAME = f"{MODULE_NAME}.py"
 
     @property
     def initial_settings_file_path(self):
         return os.path.join(
-            Projects.BACKEND,
-            Projects.BACKEND,
-            SettingsComponent.ORIGINAL_FILE_NAME
+            Projects.BACKEND, Projects.BACKEND, SettingsComponent.ORIGINAL_FILE_NAME
         )
 
     @property
     def settings_directory(self):
         return os.path.join(
-            Projects.BACKEND,
-            Projects.BACKEND,
-            SettingsComponent.DIRECTORY_NAME,
+            Projects.BACKEND, Projects.BACKEND, SettingsComponent.DIRECTORY_NAME,
         )
 
     @property
     def settings_file_path(self):
-        return os.path.join(
-            self.settings_directory,
-            SettingsComponent.FILE_NAME,
-        )
+        return os.path.join(self.settings_directory, SettingsComponent.FILE_NAME,)
 
     def parse(self):
         with repository_root():
@@ -43,5 +36,5 @@ class SettingsComponent(Component):
 
     def dump(self, data):
         with repository_root():
-            with open(self.settings_file_path, 'w') as f:
+            with open(self.settings_file_path, "w") as f:
                 f.write(data.dumps())


### PR DESCRIPTION
Following the discussion in PR#15, I thought it would be set up the
Django settings so that the app generated by Zygoat would be able to
update the settings without touching the same settings file that
Zygoat might be used to update. This moves the Django settings into
their own package, where the settings can be updated without
modifying the zygoat_settings.py file"