### PR TITLE
Add more to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Linting, test configuration, boilerplate, and development environment are automa
 
 `zygoat` also includes a preset deployment configuration to allow you to deploy your stack to an AWS environment with a single command. You'll get a full serverless AWS stack to keep things inexpensive and nimble.
 
+## How does it work?
+
+`zygoat` works by defining `Components`, defined as parts of projects, and then defining how you implement those compnents based on whether you're creating a new project, updating an existing project, or deleting a component that's no longer needed.
+
+For instance, for the python backend, we want to include `black`, which is a tool for automatically formatting python code in a standard way to make it pep8 compliant. To install `black` in for the python backend part of the project, we create a `Component` for it, specifically a `FileComponent`, which defines how we treat files that we need in projects. Then we register the `Black` component (defined in [black.py](https://github.com/bequest/zygoat/blob/master/zygoat/components/backend/black.py)) with the `Backend` component (defined in [backend/\_\_init\_\_.py](https://github.com/bequest/zygoat/blob/master/zygoat/components/backend/__init__.py)) as a sub component. This way, whenever you create or update (or delete) a project with the `Backend` component, you'll do the same 'phase' to the `Black` component.
+
 ## How do I use it?
 
 Make a new git repository somewhere, we'll call it test-zg


### PR DESCRIPTION
Adds a quick description of how components work together to make zygoat do things. This is meant to help new hires get up to speed in a directed way rather than having to dive into code or PRs so much.

@ambikads fyi