### PR TITLE
Add swp files to gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ dmypy.json
 
 # IntelliJ editors
 .idea/
+
+# Swap files
+*.swp

--- a/zygoat/components/backend/gitignore.py
+++ b/zygoat/components/backend/gitignore.py
@@ -17,6 +17,10 @@ class GitIgnore(Component):
             res.raise_for_status()
 
             f.write(res.text)
+            f.write("\n# IntelliJ editors\n.idea/")
+            # End with a newline since js-specific stuff will go into the
+            # file next.
+            f.write("\n# Swap files\n*.swp\n")
 
     @property
     def installed(self):


### PR DESCRIPTION
I usually have many tabs open and committing without this is a nightmare. Also made sure this and the IntelliJ editor stuff will get propagated to new projects.

Tested, the lines were written to file.