### PR TITLE
Fixes for eslint issues encountered when initializing Portunus

### DIFF
--- a/zygoat/components/frontend/eslint/__init__.py
+++ b/zygoat/components/frontend/eslint/__init__.py
@@ -15,6 +15,7 @@ class Eslint(Component):
     dependencies = [
         "eslint",
         "babel-eslint",
+        "babel-plugin-module-resolver",
         "eslint-import-resolver-babel-module",
     ]
 
@@ -35,6 +36,15 @@ class Eslint(Component):
 
             log.info("Installing eslint configs to frontend")
             run(["yarn", "add", "--dev", *self.configs])
+
+            log.info("Adding eslint command")
+            with open("package.json") as f:
+                data = json.load(f)
+                data["scripts"]["eslint"] = "node_modules/.bin/eslint --ext .js,.jsx ."
+
+            log.info("Dumping new frontend package file")
+            with open("package.json", "w") as f:
+                json.dump(data, f)
 
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)

--- a/zygoat/components/frontend/eslint/resources/.eslintrc.js
+++ b/zygoat/components/frontend/eslint/resources/.eslintrc.js
@@ -45,6 +45,10 @@ module.exports = {
       }
     ],
 
+    // There are many situations where libraries expect you to modify the
+    //   properties of a parameter passed to a function.
+    'no-param-reassign': ['error', { props: false }],
+
     // We want to keep spacing consistent even for the children, which is not
     //   enabled by default, but should be.
     "react/jsx-curly-spacing": [
@@ -55,13 +59,27 @@ module.exports = {
         allowMultiline: true
       }
     ]
+
+    'no-restricted-syntax': ['off'],
+    'react/jsx-filename-extension': ['off'],
+    'prettier/prettier': 'error',
+    'react/jsx-props-no-spreading': ['off'],
+    'react/forbid-prop-types': ['off'],
+    'react/no-unescaped-entities': ['off'],
+    'react/no-array-index-key': ['off'],
+    'jsx-a11y/no-static-element-interactions': ['off'],
+
+    // For components that appear more than once, this is impossible
+    'jsx-a11y/click-events-have-key-events': ['off'],
   },
 
-  "import/resolver": {
-    "babel-module": {
-      root: ["./src"],
-      alias: {
-        "@wui": "@bequestinc/wui"
+  settings: {
+    "import/resolver": {
+      "babel-module": {
+        alias: {
+          "@wui": "@bequestinc/wui",
+          "@@": "./"
+        }
       }
     }
   }


### PR DESCRIPTION
The for..of rule is one that we could consider disabling. This is a case where the airbnb rules are pretty opinionated - they prefer the use of array iteration methods like forEach.