### PR TITLE
Install a fix for SSR MUI

### DIFF
--- a/zygoat/components/frontend/dependencies/__init__.py
+++ b/zygoat/components/frontend/dependencies/__init__.py
@@ -6,6 +6,8 @@ from zygoat.components import Component
 from zygoat.utils.shell import run
 from zygoat.utils.files import use_dir
 
+from .mui import mui
+
 log = logging.getLogger()
 
 
@@ -50,4 +52,4 @@ class Dependencies(Component):
                 return True
 
 
-dependencies = Dependencies()
+dependencies = Dependencies(sub_components=[mui])

--- a/zygoat/components/frontend/dependencies/mui.py
+++ b/zygoat/components/frontend/dependencies/mui.py
@@ -1,0 +1,35 @@
+import logging
+import os
+
+from zygoat.components import Component, FileComponent
+from zygoat.constants import Projects
+from zygoat.utils.files import use_dir
+from zygoat.utils.shell import run
+
+from . import resources
+
+log = logging.getLogger()
+
+
+class MuiFile(FileComponent):
+    resource_pkg = resources
+    base_path = os.path.join(Projects.FRONTEND, "pages")
+    overwrite = False
+
+
+class App(MuiFile):
+    filename = "_app.js"
+
+
+class Document(MuiFile):
+    filename = "_document.js"
+
+
+class Mui(Component):
+    def create(self):
+        with use_dir(Projects.FRONTEND):
+            log.info("Installing material-ui core and icons")
+            run(["yarn", "add", "@material-ui/core", "@material-ui/icons"])
+
+
+mui = Mui(sub_components=[App(), Document()])

--- a/zygoat/components/frontend/dependencies/resources/_app.js
+++ b/zygoat/components/frontend/dependencies/resources/_app.js
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import Head from 'next/head';
+import CssBaseline from '@material-ui/core/CssBaseline';
+
+const App = ({ Component, pageProps }) => {
+  useEffect(() => {
+    // Remove the server-side injected CSS.
+    const jssStyles = document.querySelector('#jss-server-side');
+    if (jssStyles) {
+      jssStyles.parentElement.removeChild(jssStyles);
+    }
+  });
+
+  return (
+    <>
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+        />
+
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+        />
+      </Head>
+
+      <CssBaseline />
+      <Component {...pageProps} />
+    </>
+  );
+};
+
+App.propTypes = {
+  Component: PropTypes.elementType.isRequired,
+  pageProps: PropTypes.object,
+};
+
+App.defaultProps = {
+  pageProps: {},
+};
+
+export default App;

--- a/zygoat/components/frontend/dependencies/resources/_document.js
+++ b/zygoat/components/frontend/dependencies/resources/_document.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import Document, { Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheets } from '@material-ui/core/styles';
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <html lang="en">
+        <Head>
+          <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    );
+  }
+}
+
+MyDocument.getInitialProps = async ctx => {
+  // Resolution order
+  //
+  // On the server:
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. document.getInitialProps
+  // 4. app.render
+  // 5. page.render
+  // 6. document.render
+  //
+  // On the server with error:
+  // 1. document.getInitialProps
+  // 2. app.render
+  // 3. page.render
+  // 4. document.render
+  //
+  // On the client
+  // 1. app.getInitialProps
+  // 2. page.getInitialProps
+  // 3. app.render
+  // 4. page.render
+
+  // Render app and page and get the context of the page with collected side effects.
+  const sheets = new ServerStyleSheets();
+  const originalRenderPage = ctx.renderPage;
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: App => props => sheets.collect(<App {...props} />),
+    });
+
+  const initialProps = await Document.getInitialProps(ctx);
+
+  return {
+    ...initialProps,
+    // Styles fragment is rendered after the app and page rendering finish.
+    styles: [...React.Children.toArray(initialProps.styles), sheets.getStyleElement()],
+  };
+};

--- a/zygoat/components/frontend/prettier/resources/.prettierrc
+++ b/zygoat/components/frontend/prettier/resources/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "endOfLine": "lf",
-  "printWidth": 100
+  "printWidth": 100,
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
JSS (the library MUI is using under the hood for CSS in JS) does not much care for being server side rendered, as when the class names are generated they're seeded based on some obtuse format. When the rendered bundle gets sent to the client and then hydrated, it gets a bit fussy and waits until the hook is called again to fix rendering.

This is obviously a bit suboptimal.

This uses the official MUI recommended solution of generating and collecting the style sheets on the server to get the expensive theme calls out of the way, and then on the client side runs the name generation so it's seeded properly.