### PR TITLE
Add in ignoring settings issues to .flake8

### DIFF
--- a/zygoat/components/backend/flake8/resources/.flake8
+++ b/zygoat/components/backend/flake8/resources/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 95
 exclude = .git, __pycache, .pycharm_helpers, */migrations/*, node_modules, bower_components, venv
+per-file-ignores = backend/backend/settings/__init__.py:F405
 extend-ignore = E126,B003,Q001,A003,E203,E501,Q000,C812,E231,C819
 # See https://github.com/PyCQA/pycodestyle/issues/373


### PR DESCRIPTION
This will be the same across all Zygoat projects I suspect and so we should put it in Zygoat.

RFC: Doing `zg update` wiped this line out because it overwrote the file with the zygoat file. Do we want to enforce when updating that we wipe out custom settings for different projects? On the one hand, individual projects should be able to set custom settings themselves. On the other, this file should only be for very limited exceptions that can't be gotten around, and then it makes sense to have it in Zygoat and enforce no custom ones. I lean towards just enforcing the same with Zygoat, but want to see what others think.