### PR TITLE
Point black to config file for precommit hooks

### DIFF
--- a/zygoat/components/resources/.pre-commit-config.yaml
+++ b/zygoat/components/resources/.pre-commit-config.yaml
@@ -24,4 +24,5 @@ repos:
     rev: stable
     hooks:
     - id: black
+      args: [--config, backend/pyproject.toml]
       language_version: python3.7


### PR DESCRIPTION
Perhaps I shouldn't have added the precommit hooks before we added in the config files. Saw some changes made during development that weren't in line with line lengths we'd agreed on. This makes sure we use the config file. Tested on some portunus changes I'm making.

This should be the last change to pre-commits necessary, I don't see any others that would need a config file that aren't being pointed to that already.