### PR TITLE
Various fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/__init__.py
+++ b/zygoat/__init__.py
@@ -5,5 +5,3 @@ from . import utils  # noqa
 import sys
 
 sys.tracebacklimit = 2
-
-__version__ = "0.1.0"

--- a/zygoat/cli.py
+++ b/zygoat/cli.py
@@ -3,7 +3,7 @@ import logging
 
 from .components import components
 from .config import Config
-from .constants import Phases, config_file_name
+from .constants import Phases, config_file_name, __version__
 
 log = logging.getLogger()
 
@@ -50,11 +50,6 @@ def new(project_name):
     )
 
 
-@cli.command(help="Create components without initializing a new project")
-def create():
-    _call_phase(Phases.CREATE)
-
-
 @cli.command(help="Lists all of the running phase names")
 def list():
     _call_phase(Phases.LIST)
@@ -71,3 +66,8 @@ def delete():
 @cli.command(help="Calls the update phase on all included build components")
 def update():
     _call_phase(Phases.UPDATE)
+
+
+@cli.command(help="Prints the version and exits")
+def version():
+    log.info(f"Running zygoat v{__version__}")

--- a/zygoat/components/backend/__init__.py
+++ b/zygoat/components/backend/__init__.py
@@ -3,9 +3,8 @@ import os
 import shutil
 
 from .. import Component
-from zygoat.utils.files import use_dir
 from zygoat.utils.shell import run
-from zygoat.constants import Projects, VENV
+from zygoat.constants import Projects
 
 from .dockerfile import dockerfile
 from .wait_command import wait_command
@@ -27,13 +26,6 @@ class Backend(Component):
 
         log.info("Creating the django project")
         run(["django-admin", "startproject", Projects.BACKEND])
-
-        with use_dir(Projects.BACKEND):
-            log.info("Creating a virtualenv for the project")
-            run(["virtualenv", VENV])
-
-    def update(self):
-        pass
 
     def delete(self):
         log.warning(f"Deleting the {Projects.BACKEND} project")

--- a/zygoat/components/backend/reformat.py
+++ b/zygoat/components/backend/reformat.py
@@ -1,8 +1,8 @@
 import logging
-import os
+from shutil import which
 
 from zygoat.components import Component
-from zygoat.constants import Phases, Projects, VENV
+from zygoat.constants import Phases, Projects
 from zygoat.utils.files import use_dir
 from zygoat.utils.shell import run
 
@@ -12,9 +12,9 @@ log = logging.getLogger()
 class Reformat(Component):
     def create(self):
         with use_dir(Projects.BACKEND):
-            black = os.path.join(VENV, "bin", "black")
-            if os.path.exists(black):
-                run([black, ".", "--exclude", VENV])
+            black = which("black")
+            if black is not None:
+                run([black, "."])
 
     def update(self):
         self.call_phase(Phases.CREATE, force_create=True)

--- a/zygoat/components/backend/settings/reverse_proxy.py
+++ b/zygoat/components/backend/settings/reverse_proxy.py
@@ -8,11 +8,14 @@ from . import resources
 
 log = logging.getLogger()
 
+import_path = "backend.proxy.ReverseProxyHandlingMiddleware"
+
 
 class ProxyFile(FileComponent):
     resource_pkg = resources
     base_path = os.path.join(Projects.BACKEND, Projects.BACKEND)
     filename = "proxy.py"
+    overwrite = False
 
 
 class SettingsEntry(SettingsComponent):
@@ -21,9 +24,16 @@ class SettingsEntry(SettingsComponent):
         middleware_list = red.find("name", "MIDDLEWARE").parent.value
 
         log.info("Adding reverse proxy middleware")
-        middleware_list.insert(0, "'backend.proxy.ReverseProxyHandlingMiddleware'")
+        middleware_list.insert(0, f"'{import_path}'")
 
         self.dump(red)
+
+    @property
+    def installed(self):
+        red = self.parse()
+        middleware_list = red.find("name", "MIDDLEWARE").parent.value.to_python()
+
+        return import_path in middleware_list
 
 
 # Just a shell for hosting the other two components

--- a/zygoat/components/base.py
+++ b/zygoat/components/base.py
@@ -93,6 +93,12 @@ class Component:
 
         self.reload()
 
+        if phase == Phases.UPDATE and not self.installed:
+            log.info(
+                "Update phase called for a non-installed component, running the create phase instead"
+            )
+            return self.call_phase(Phases.CREATE)
+
         run_self = partial(self._run_self, phase, force_create=force_create)
         run_children = partial(self._run_children, phase)
 

--- a/zygoat/config.py
+++ b/zygoat/config.py
@@ -7,9 +7,8 @@ from click import style
 from ruamel.yaml import YAML
 import logging
 
-from . import __version__
 from .utils.files import find_nearest
-from .constants import config_file_name
+from .constants import config_file_name, __version__
 
 
 yaml = YAML(typ="safe")

--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -1,3 +1,5 @@
+import importlib
+
 from box import Box
 
 
@@ -18,3 +20,5 @@ Phases = Box([(t.upper(), t) for t in phase_function_names])
 Projects = Box([(t.upper(), t) for t in project_dir_names])
 
 VENV = "venv"
+
+__version__ = importlib.metadata.version("zygoat")

--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -19,6 +19,4 @@ project_dir_names = [
 Phases = Box([(t.upper(), t) for t in phase_function_names])
 Projects = Box([(t.upper(), t) for t in project_dir_names])
 
-VENV = "venv"
-
 __version__ = version("zygoat")

--- a/zygoat/constants.py
+++ b/zygoat/constants.py
@@ -1,4 +1,4 @@
-import importlib
+from importlib_metadata import version
 
 from box import Box
 
@@ -21,4 +21,4 @@ Projects = Box([(t.upper(), t) for t in project_dir_names])
 
 VENV = "venv"
 
-__version__ = importlib.metadata.version("zygoat")
+__version__ = version("zygoat")

--- a/zygoat/utils/backend.py
+++ b/zygoat/utils/backend.py
@@ -1,10 +1,11 @@
 import os
+from shutil import which
 
 from .shell import run
 from .files import use_dir, repository_root
-from zygoat.constants import Projects, VENV
+from zygoat.constants import Projects
 
-pip = os.path.join(VENV, "bin", "pip")
+pip = which("pip")
 dev_file_name = "requirements.dev.txt"
 prod_file_name = "requirements.txt"
 


### PR DESCRIPTION
 - `zg update` now installs new components that are not excluded
 - The reverse proxy middleware properly detects its own installation and does not duplicate it
 - We no longer enforce a virtual environment, as most users have their own preference on how to do that
 - New `zg version` command