### PR TITLE
Create and use helper function for production required env vars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zygoat"
-version = "0.4.1"
+version = "0.5.0"
 description = ""
 authors = ["Bequest, Inc. <oss@willing.com>"]
 readme = "README.md"

--- a/zygoat/components/backend/settings/__init__.py
+++ b/zygoat/components/backend/settings/__init__.py
@@ -11,6 +11,7 @@ from .allowed_hosts import allowed_hosts
 from .cookies import cookies
 from .drf_camelize import drf_camelize
 from .reverse_proxy import reverse_proxy
+from .env import env
 
 log = logging.getLogger()
 
@@ -37,14 +38,6 @@ class Settings(SettingsComponent):
         log.info("Adding comment to Zygoat settings file")
         red[0].value = zygoat_settings_comment
 
-        first_import_index = red.index(red.find("importnode"))
-
-        log.info("Inserting environ import into django settings")
-        red.insert(first_import_index + 1, "import environ")
-
-        log.info("Inserting environ constructor")
-        red.insert(first_import_index + 2, "env = environ.Env()")
-
         log.info("Dumping django settings file")
         self.dump(red)
 
@@ -62,6 +55,7 @@ settings_sub_components = [
     cookies,
     drf_camelize,
     reverse_proxy,
+    env,
 ]
 
 settings = Settings(sub_components=settings_sub_components)

--- a/zygoat/components/backend/settings/allowed_hosts.py
+++ b/zygoat/components/backend/settings/allowed_hosts.py
@@ -11,7 +11,7 @@ class AllowedHosts(SettingsComponent):
         host_list = red.find("name", value="ALLOWED_HOSTS").parent.value
 
         log.info("Adding allowed host environment config")
-        host_list.append("env('DJANGO_ALLOWED_HOST', default='*')")
+        host_list.append("prod_required_env('DJANGO_ALLOWED_HOST', default='*')")
 
         log.info("Dumping installed apps node")
         self.dump(red)

--- a/zygoat/components/backend/settings/env.py
+++ b/zygoat/components/backend/settings/env.py
@@ -1,0 +1,44 @@
+import logging
+
+from zygoat.components import SettingsComponent
+
+log = logging.getLogger()
+
+# If this string starts with a blank line, RedBaron completely ignores it
+settings_string = """def prod_required_env(key, default, method="str"):
+    \"\"\"Throw an exception if PRODUCTION is true and key is not provided\"\"\"
+    if PRODUCTION:
+        default = environ.Env.NOTSET
+    return getattr(env, method)(key, default)
+
+"""
+
+
+class Env(SettingsComponent):
+    def create(self):
+        red = self.parse()
+
+        first_import_index = red.index(red.find("importnode"))
+
+        log.info("Inserting environ import into django settings")
+        red.insert(first_import_index + 1, "import environ")
+
+        log.info("Inserting environ constructor")
+
+        red.insert(first_import_index + 2, "env = environ.Env()")
+
+        log.info("Inserting prod_required_env function")
+        index = red.index(red.find("name", "PRODUCTION").parent)
+        red.insert(index + 1, "\n")
+        red.insert(index + 2, "\n")
+        red.insert(index + 3, settings_string)
+
+        self.dump(red)
+
+    @property
+    def installed(self):
+        red = self.parse()
+        return red.find("def", "prod_required_env") is not None
+
+
+env = Env()

--- a/zygoat/components/backend/settings/secret_key.py
+++ b/zygoat/components/backend/settings/secret_key.py
@@ -14,7 +14,7 @@ class SecretKey(SettingsComponent):
         default_key = key_node.value.to_python()
 
         log.info("Relocating default secret key")
-        key_node.value = f"env.str('DJANGO_SECRET_KEY', default='{default_key}')"
+        key_node.value = f"prod_required_env('DJANGO_SECRET_KEY', default='{default_key}')"
 
         log.info("Dumping secret key node")
         self.dump(red)


### PR DESCRIPTION
This adds a helper function to the zygoat settings that be used to require environment variables are set in production.